### PR TITLE
feat: add prove generation, witness and meta 

### DIFF
--- a/core/types/meta.go
+++ b/core/types/meta.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type StateMeta interface {
+	GetVersionNumber() uint8
+	Hash() common.Hash
+}
+
+type MetaNoConsensus struct {
+	Version uint8
+	Epoch   uint16
+}
+
+func (m *MetaNoConsensus) GetVersionNumber() uint8 {
+	return m.Version
+}
+
+func (m *MetaNoConsensus) Hash() common.Hash {
+	return rlpHash(m.Epoch)
+}

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -33,6 +33,7 @@ type StateAccount struct {
 	Balance  *big.Int
 	Root     common.Hash // merkle root of the storage trie
 	CodeHash []byte
+	MetaHash common.Hash `rlp:"-"` // TODO (asyukii): handle this
 }
 
 // NewEmptyStateAccount constructs an empty state account.

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -73,6 +73,31 @@ func makeProvers(trie *Trie) []func(key []byte) *memorydb.Database {
 	return provers
 }
 
+func TestOneElementPathProof(t *testing.T) {
+	trie := NewEmpty(NewDatabase(rawdb.NewMemoryDatabase()))
+	updateString(trie, "k", "v")
+
+	var proofList proofList
+
+	trie.Prove([]byte("k"), &proofList)
+	if proofList == nil {
+		t.Fatalf("nil proof")
+	}
+
+	if len(proofList) != 1 {
+		t.Errorf("proof should have one element")
+	}
+
+	_, hn, err := VerifyPathProof(keybytesToHex([]byte("k")), nil, proofList)
+	if err != nil {
+		t.Fatalf("failed to verify proof: %v\nraw proof: %x", err, proofList)
+	}
+
+	if common.BytesToHash(hn) != trie.Hash() {
+		t.Fatalf("verified root mismatch: have %x, want %x", hn, trie.Hash())
+	}
+}
+
 func TestProof(t *testing.T) {
 	trie, vals := randomTrie(500)
 	root := trie.Hash()
@@ -899,6 +924,17 @@ func TestAllElementsEmptyValueRangeProof(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected failure on noop entry")
 	}
+}
+
+type proofList [][]byte
+
+func (n *proofList) Put(key []byte, value []byte) error {
+	*n = append(*n, value)
+	return nil
+}
+
+func (n *proofList) Delete(key []byte) error {
+	panic("not supported")
 }
 
 // mutateByte changes one byte in b.

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -670,3 +670,136 @@ func (t *Trie) Reset() {
 	t.tracer.reset()
 	t.committed = false
 }
+
+// ReviveTrie revives a trie by prefix key with the given proof list.
+func (t *Trie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) {
+	key = keybytesToHex(key)
+
+	// Verify the proof first
+	revivedNode, revivedHash, err := VerifyPathProof(key, prefixKeyHex, proofList)
+	if err != nil {
+		log.Error("Failed to verify proof", "err", err)
+	}
+
+	newRoot, _, err := t.revive(t.root, key, prefixKeyHex, 0, revivedNode, common.BytesToHash(revivedHash))
+	if err != nil {
+		log.Error("Failed to revive trie", "err", err)
+	}
+	t.root = newRoot
+}
+
+func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedNode node, revivedHash common.Hash) (node, bool, error) {
+
+	if pos > len(prefixKeyHex) {
+		return nil, false, fmt.Errorf("target revive node not found")
+	}
+
+	if pos == len(prefixKeyHex) {
+		hn, ok := n.(hashNode)
+		if !ok {
+			return nil, false, fmt.Errorf("prefix key path does not lead to a hash node")
+		}
+
+		// Compare the hash of the revived node with the hash of the hash node
+		if revivedHash != common.BytesToHash(hn) {
+			return nil, false, fmt.Errorf("revived node hash does not match the hash node hash")
+		}
+
+		return revivedNode, true, nil
+	}
+
+	switch n := n.(type) {
+	case *shortNode:
+		if len(key)-pos < len(n.Key) || !bytes.Equal(n.Key, key[pos:pos+len(n.Key)]) {
+			// key not found in trie
+			return n, false, nil
+		}
+		newNode, didRevived, err := t.revive(n.Val, key, prefixKeyHex, pos+len(n.Key), revivedNode, revivedHash)
+		if err == nil && didRevived {
+			n = n.copy()
+			n.Val = newNode
+		}
+		return n, didRevived, err
+	case *fullNode:
+		childIndex := int(key[pos])
+		newNode, didRevived, err := t.revive(n.Children[childIndex], key, prefixKeyHex, pos+1, revivedNode, revivedHash)
+		if err == nil && didRevived {
+			n = n.copy()
+			n.Children[key[pos]] = newNode
+		}
+		return n, didRevived, err
+	case hashNode:
+		child, err := t.resolveAndTrack(n, key[:pos])
+		if err != nil {
+			return nil, false, err
+		}
+		newNode, _, err := t.revive(child, key, prefixKeyHex, pos, revivedNode, revivedHash)
+		return newNode, true, err
+	case nil:
+		return nil, false, nil
+	default:
+		panic(fmt.Sprintf("invalid node: %T", n))
+	}
+}
+
+// ExpireByPrefix is used to simulate the expiration of a trie by prefix key.
+// It is not used in the actual trie implementation. ExpireByPrefix makes sure
+// only a child node of a full node is expired, if not an error is returned.
+func (t *Trie) ExpireByPrefix(prefixKeyHex []byte) error {
+	hn, err := t.expireByPrefix(t.root, prefixKeyHex)
+	if prefixKeyHex == nil && hn != nil {
+		t.root = hn
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t *Trie) expireByPrefix(n node, prefixKeyHex []byte) (node, error) {
+	// Loop through prefix key
+	// When prefix key is empty, generate the hash node of the current node
+	// Replace current node with the hash node
+
+	if len(prefixKeyHex) == 0 {
+		hasher := newHasher(false)
+		defer returnHasherToPool(hasher)
+		var hn node
+		_, hn = hasher.proofHash(n)
+		if _, ok := hn.(hashNode); ok {
+			return hn, nil
+		}
+
+		return nil, nil
+	}
+
+	switch n := n.(type) {
+	case *shortNode:
+		matchLen := prefixLen(prefixKeyHex, n.Key)
+		hn, err := t.expireByPrefix(n.Val, prefixKeyHex[matchLen:])
+		if err != nil {
+			return nil, err
+		}
+
+		if hn != nil {
+			return nil, fmt.Errorf("can only expire child short node")
+		}
+
+		return nil, err
+	case *fullNode:
+		childIndex := int(prefixKeyHex[0])
+		hn, err := t.expireByPrefix(n.Children[childIndex], prefixKeyHex[1:])
+		if err != nil {
+			return nil, err
+		}
+
+		// Replace child node with hash node
+		if hn != nil {
+			n.Children[prefixKeyHex[0]] = hn
+		}
+
+		return nil, err
+	default:
+		return nil, fmt.Errorf("invalid node type")
+	}
+}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie/trienode"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/sha3"
 )
 
@@ -982,6 +983,86 @@ func TestCommitSequenceSmallRoot(t *testing.T) {
 	if got, exp := stackTrieSponge.sponge.Sum(nil), s.sponge.Sum(nil); !bytes.Equal(got, exp) {
 		t.Fatalf("test, disk write sequence wrong:\ngot %x exp %x\n", got, exp)
 	}
+}
+
+func TestReviveCustom(t *testing.T) {
+
+	data := map[string]string{
+		"abcd": "A", "abce": "B", "abde": "C", "abdf": "D",
+		"defg": "E", "defh": "F", "degh": "G", "degi": "H",
+	}
+
+	trie := createCustomTrie(data)
+
+	oriRootHash := trie.Hash()
+
+	for k, v := range data {
+		key := []byte(k)
+		val := []byte(v)
+		prefixKeys := getFullNodePrefixKeys(trie, key)
+		for _, prefixKey := range prefixKeys {
+			var proofList proofList
+			err := trie.ProvePath(key, prefixKey, &proofList)
+			assert.NoError(t, err)
+
+			trie.ExpireByPrefix(prefixKey)
+
+			trie.ReviveTrie(key, prefixKey, proofList)
+
+			v := trie.MustGet(key)
+			assert.Equal(t, val, v)
+
+			// Verify root hash
+			currRootHash := trie.Hash()
+			assert.Equal(t, oriRootHash, currRootHash, "root hash mismatch, got %x, exp %x, key %x, prefixKey %x", currRootHash, oriRootHash, key, prefixKey)
+
+			// Reset trie
+			trie = createCustomTrie(data)
+		}
+	}
+}
+
+func createCustomTrie(data map[string]string) *Trie {
+	trie := NewEmpty(NewDatabase(rawdb.NewMemoryDatabase()))
+	for k, v := range data {
+		trie.MustUpdate([]byte(k), []byte(v))
+	}
+
+	return trie
+}
+
+func getFullNodePrefixKeys(t *Trie, key []byte) [][]byte {
+	var prefixKeys [][]byte
+	key = keybytesToHex(key)
+	tn := t.root
+	currPath := []byte{}
+	for len(key) > 0 && tn != nil {
+		switch n := tn.(type) {
+		case *shortNode:
+			if len(key) < len(n.Key) || !bytes.Equal(n.Key, key[:len(n.Key)]) {
+				// The trie doesn't contain the key.
+				tn = nil
+			} else {
+				tn = n.Val
+				prefixKeys = append(prefixKeys, currPath)
+				currPath = append(currPath, n.Key...)
+				key = key[len(n.Key):]
+			}
+		case *fullNode:
+			tn = n.Children[key[0]]
+			currPath = append(currPath, key[0])
+			key = key[1:]
+		default:
+			return nil
+		}
+	}
+
+	// Remove the first item in prefixKeys, which is the empty key
+	if len(prefixKeys) > 0 {
+		prefixKeys = prefixKeys[1:]
+	}
+
+	return prefixKeys
 }
 
 // BenchmarkCommitAfterHashFixedSize benchmarks the Commit (after Hash) of a fixed number of updates to a trie.


### PR DESCRIPTION
**Description**
Add features to generate proof from prefix key, revive from the prefix, and basic meta info.

**Changes**
- Can generate proof from a subtree
- Can revive a trie using a proof
- StateAccount now has MetaHash