### PR TITLE
feat: implement epoch-based trie and RPC

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -130,6 +130,8 @@ type Trie interface {
 	// nodes of the longest existing prefix of the key (at least the root), ending
 	// with the node that proves the absence of the key.
 	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
+
+	ProvePath(key []byte, path []byte, proofDb ethdb.KeyValueWriter) error
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -78,6 +78,12 @@ type StorageResult struct {
 	Proof []string `json:"proof"`
 }
 
+type ReviveStorageResult struct {
+	Key       string   `json:"key"`
+	PrefixKey string   `json:"prefixKey"`
+	Proof     []string `json:"proof"`
+}
+
 // GetProof returns the account and storage values of the specified account including the Merkle-proof.
 // The block number can be nil, in which case the value is taken from the latest known block.
 func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []string, blockNumber *big.Int) (*AccountResult, error) {
@@ -123,6 +129,24 @@ func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []s
 		StorageProof: storageResults,
 	}
 	return &result, err
+}
+
+// GetStorageReviveProof returns the proof for the given keys. Prefix keys can be specified to obtain partial proof for a given key.
+// Both keys and prefix keys should have the same length. If user wish to obtain full proof for a given key, the corresponding prefix key should be empty string.
+func (ec *Client) GetStorageReviveProof(ctx context.Context, account common.Address, keys []string, prefixKeys []string, hash common.Hash) ([]ReviveStorageResult, error) {
+	var err error
+	storageResults := make([]ReviveStorageResult, 0, len(keys))
+
+	if len(keys) != len(prefixKeys) {
+		return nil, fmt.Errorf("keys and prefixKeys must be same length")
+	}
+
+	if hash == (common.Hash{}) {
+		err = ec.c.CallContext(ctx, &storageResults, "eth_getStorageReviveProof", account, keys, prefixKeys, "latest")
+	} else {
+		err = ec.c.CallContext(ctx, &storageResults, "eth_getStorageReviveProof", account, keys, prefixKeys, hash)
+	}
+	return storageResults, err
 }
 
 // CallContract executes a message call transaction, which is directly executed in the VM

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -106,6 +106,9 @@ func TestGethClient(t *testing.T) {
 			"TestGetProof",
 			func(t *testing.T) { testGetProof(t, client) },
 		}, {
+			"TestGetStorageReviveProof",
+			func(t *testing.T) { testGetStorageReviveProof(t, client) },
+		}, {
 			"TestGetProofCanonicalizeKeys",
 			func(t *testing.T) { testGetProofCanonicalizeKeys(t, client) },
 		}, {
@@ -233,6 +236,27 @@ func testGetProof(t *testing.T, client *rpc.Client) {
 	}
 	if proof.Key != testSlot.String() {
 		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), proof.Key)
+	}
+}
+
+func testGetStorageReviveProof(t *testing.T, client *rpc.Client) {
+	ec := New(client)
+	result, err := ec.GetStorageReviveProof(context.Background(), testAddr, []string{testSlot.String()}, []string{""}, common.Hash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test storage
+	if len(result) != 1 {
+		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(result))
+	}
+
+	if result[0].Key != testSlot.String() {
+		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), result[0].Key)
+	}
+
+	if result[0].PrefixKey != "" {
+		t.Fatalf("invalid storage proof prefix key, want: %q, got: %q", "", result[0].PrefixKey)
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -655,6 +655,12 @@ type StorageResult struct {
 	Proof []string     `json:"proof"`
 }
 
+type ReviveStorageResult struct {
+	Key       string   `json:"key"`
+	PrefixKey string   `json:"prefixKey"`
+	Proof     []string `json:"proof"`
+}
+
 // proofList implements ethdb.KeyValueWriter and collects the proofs as
 // hex-strings for delivery to rpc-caller.
 type proofList []string
@@ -741,6 +747,76 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 		StorageHash:  storageHash,
 		StorageProof: storageProof,
 	}, state.Error()
+}
+
+// GetStorageReviveProof returns the proof for the given keys. Prefix keys can be specified to obtain partial proof for a given key.
+// Both keys and prefix keys should have the same length. If user wish to obtain full proof for a given key, the corresponding prefix key should be empty string.
+func (s *BlockChainAPI) GetStorageReviveProof(ctx context.Context, address common.Address, storageKeys []string, storagePrefixKeys []string, blockNrOrHash rpc.BlockNumberOrHash) ([]ReviveStorageResult, error) {
+
+	if len(storageKeys) != len(storagePrefixKeys) {
+		return nil, errors.New("storageKeys and storagePrefixKeys must be same length")
+	}
+
+	var (
+		keys         = make([]common.Hash, len(storageKeys))
+		keyLengths   = make([]int, len(storageKeys))
+		prefixKeys   = make([][]byte, len(storagePrefixKeys))
+		storageProof = make([]ReviveStorageResult, len(storageKeys))
+		storageTrie  state.Trie
+	)
+	// Deserialize all keys. This prevents state access on invalid input.
+	for i, hexKey := range storageKeys {
+		var err error
+		keys[i], keyLengths[i], err = decodeHash(hexKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Decode prefix keys
+	for i, prefixKey := range storagePrefixKeys {
+		var err error
+		prefixKeys[i], err = hex.DecodeString(prefixKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	if storageTrie, err = state.StorageTrie(address); err != nil {
+		return nil, err
+	}
+
+	// Must have storage trie
+	if storageTrie == nil {
+		return nil, errors.New("storageTrie is nil")
+	}
+
+	// Create the proofs for the storageKeys.
+	for i, key := range keys {
+		// Output key encoding is a bit special: if the input was a 32-byte hash, it is
+		// returned as such. Otherwise, we apply the QUANTITY encoding mandated by the
+		// JSON-RPC spec for getProof. This behavior exists to preserve backwards
+		// compatibility with older client versions.
+		var outputKey string
+		if keyLengths[i] != 32 {
+			outputKey = hexutil.EncodeBig(key.Big())
+		} else {
+			outputKey = hexutil.Encode(key[:])
+		}
+
+		var proof proofList
+		prefixKey := prefixKeys[i]
+		if err := storageTrie.ProvePath(crypto.Keccak256(key.Bytes()), prefixKey, &proof); err != nil {
+			return nil, err
+		}
+		storageProof[i] = ReviveStorageResult{outputKey, storagePrefixKeys[i], proof}
+	}
+
+	return storageProof, nil
 }
 
 // decodeHash parses a hex-encoded 32-byte hash. The input may optionally

--- a/light/trie.go
+++ b/light/trie.go
@@ -203,6 +203,10 @@ func (t *odrTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	return errors.New("not implemented, needs client/server interface split")
 }
 
+func (t *odrTrie) ProvePath(key []byte, path []byte, proofDb ethdb.KeyValueWriter) error {
+	return errors.New("not implemented, needs client/server interface split")
+}
+
 // do tries and retries to execute a function until it returns with no error or
 // an error type other than MissingNodeError
 func (t *odrTrie) do(key []byte, fn func() error) error {

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 )
 
 // ErrCommitted is returned when a already committed trie is requested for usage.
@@ -49,4 +50,20 @@ func (err *MissingNodeError) Error() string {
 		return fmt.Sprintf("missing trie node %x (path %x) %v", err.NodeHash, err.Path, err.err)
 	}
 	return fmt.Sprintf("missing trie node %x (owner %x) (path %x) %v", err.NodeHash, err.Owner, err.Path, err.err)
+}
+
+type ExpiredNodeError struct {
+	Path  []byte // hex-encoded path to the expired node
+	Epoch types.StateEpoch
+}
+
+func NewExpiredNodeError(path []byte, epoch types.StateEpoch) error {
+	return &ExpiredNodeError{
+		Path:  path,
+		Epoch: epoch,
+	}
+}
+
+func (err *ExpiredNodeError) Error() string {
+	return "expired trie node"
 }

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -315,7 +315,7 @@ func updateEpochInChildNodes(tn *node, key []byte, epoch types.StateEpoch) error
 	node := *tn
 	startNode := node
 
-	for len(key) > 0 && tn != nil {
+	for len(key) > 0 && node != nil {
 		switch n := node.(type) {
 		case *shortNode:
 			if len(key) < len(n.Key) || !bytes.Equal(n.Key, key[:len(n.Key)]) {

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -88,7 +88,7 @@ func TestOneElementPathProof(t *testing.T) {
 		t.Errorf("proof should have one element")
 	}
 
-	_, hn, err := VerifyPathProof(keybytesToHex([]byte("k")), nil, proofList)
+	_, hn, err := VerifyPathProof(keybytesToHex([]byte("k")), nil, proofList, 0)
 	if err != nil {
 		t.Fatalf("failed to verify proof: %v\nraw proof: %x", err, proofList)
 	}
@@ -1100,6 +1100,23 @@ func nonRandomTrie(n int) (*Trie, map[string]*kv) {
 		binary.LittleEndian.PutUint64(key, i)
 		binary.LittleEndian.PutUint64(value, i-max)
 		//value := &kv{common.LeftPadBytes([]byte{i}, 32), []byte{i}, false}
+		elem := &kv{key, value, false}
+		trie.MustUpdate(elem.k, elem.v)
+		vals[string(elem.k)] = elem
+	}
+	return trie, vals
+}
+
+func nonRandomTrieWithExpiry(n int) (*Trie, map[string]*kv) {
+	db := NewDatabase(rawdb.NewMemoryDatabase())
+	trie := NewEmptyWithExpiry(db, 10)
+	vals := make(map[string]*kv)
+	max := uint64(0xffffffffffffffff)
+	for i := uint64(0); i < uint64(n); i++ {
+		value := make([]byte, 32)
+		key := make([]byte, 32)
+		binary.LittleEndian.PutUint64(key, i)
+		binary.LittleEndian.PutUint64(value, i-max)
 		elem := &kv{key, value, false}
 		trie.MustUpdate(elem.k, elem.v)
 		vals[string(elem.k)] = elem

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -37,7 +37,7 @@ import (
 // Trie is not safe for concurrent use.
 type Trie struct {
 	root  node
-	owner common.Hash
+	owner common.Hash // Can be used to identify account vs storage trie
 
 	// Flag whether the commit operation is already performed. If so the
 	// trie is not usable(latest states is invisible).
@@ -49,11 +49,15 @@ type Trie struct {
 	unhashed int
 
 	// reader is the handler trie can retrieve nodes from.
-	reader *trieReader
+	reader *trieReader // TODO (asyukii): create a reader for state expiry metadata
 
 	// tracer is the tool to track the trie changes.
 	// It will be reset after each commit operation.
 	tracer *tracer
+
+	// fields for state expiry
+	rootEpoch    types.StateEpoch
+	enableExpiry bool
 }
 
 // newFlag returns the cache flag value for a newly created node.
@@ -64,12 +68,14 @@ func (t *Trie) newFlag() nodeFlag {
 // Copy returns a copy of Trie.
 func (t *Trie) Copy() *Trie {
 	return &Trie{
-		root:      t.root,
-		owner:     t.owner,
-		committed: t.committed,
-		unhashed:  t.unhashed,
-		reader:    t.reader,
-		tracer:    t.tracer.copy(),
+		root:         t.root,
+		owner:        t.owner,
+		committed:    t.committed,
+		unhashed:     t.unhashed,
+		reader:       t.reader,
+		tracer:       t.tracer.copy(),
+		rootEpoch:    t.rootEpoch,
+		enableExpiry: t.enableExpiry,
 	}
 }
 
@@ -103,6 +109,36 @@ func New(id *ID, db *Database) (*Trie, error) {
 func NewEmpty(db *Database) *Trie {
 	tr, _ := New(TrieID(types.EmptyRootHash), db)
 	return tr
+}
+
+func NewEmptyWithExpiry(db *Database, rootEpoch types.StateEpoch) *Trie {
+	tr, _ := New(TrieID(types.EmptyRootHash), db)
+	tr.enableExpiry = true
+	tr.rootEpoch = rootEpoch
+	return tr
+}
+
+// TODO (asyukii): handle meta storage later
+func NewWithExpiry(id *ID, db *Database, rootEpoch types.StateEpoch) (*Trie, error) {
+	reader, err := newTrieReader(id.StateRoot, id.Owner, db)
+	if err != nil {
+		return nil, err
+	}
+	trie := &Trie{
+		owner:        id.Owner,
+		reader:       reader,
+		tracer:       newTracer(),
+		rootEpoch:    rootEpoch,
+		enableExpiry: true,
+	}
+	if id.Root != (common.Hash{}) && id.Root != types.EmptyRootHash {
+		rootnode, err := trie.resolveAndTrack(id.Root[:], nil)
+		if err != nil {
+			return nil, err
+		}
+		trie.root = rootnode
+	}
+	return trie, nil
 }
 
 // MustNodeIterator is a wrapper of NodeIterator and will omit any encountered
@@ -140,12 +176,20 @@ func (t *Trie) MustGet(key []byte) []byte {
 //
 // If the requested node is not present in trie, no error will be returned.
 // If the trie is corrupted, a MissingNodeError is returned.
-func (t *Trie) Get(key []byte) ([]byte, error) {
+func (t *Trie) Get(key []byte) (value []byte, err error) {
+	var newroot node
+	var didResolve bool
+
 	// Short circuit if the trie is already committed and not usable.
 	if t.committed {
 		return nil, ErrCommitted
 	}
-	value, newroot, didResolve, err := t.get(t.root, keybytesToHex(key), 0)
+
+	if t.enableExpiry {
+		value, newroot, didResolve, err = t.getWithEpoch(t.root, keybytesToHex(key), 0, t.getRootEpoch())
+	} else {
+		value, newroot, didResolve, err = t.get(t.root, keybytesToHex(key), 0)
+	}
 	if err == nil && didResolve {
 		t.root = newroot
 	}
@@ -182,6 +226,56 @@ func (t *Trie) get(origNode node, key []byte, pos int) (value []byte, newnode no
 			return nil, n, true, err
 		}
 		value, newnode, _, err := t.get(child, key, pos)
+		return value, newnode, true, err
+	default:
+		panic(fmt.Sprintf("%T: invalid node: %v", origNode, origNode))
+	}
+}
+
+func (t *Trie) getWithEpoch(origNode node, key []byte, pos int, epoch types.StateEpoch) (value []byte, newnode node, didResolve bool, err error) {
+	if t.epochExpired(origNode, epoch) {
+		return nil, nil, false, NewExpiredNodeError(key[:pos], epoch)
+	}
+	switch n := (origNode).(type) {
+	case nil:
+		return nil, nil, false, nil
+	case valueNode:
+		return n, n, false, nil
+	case *shortNode:
+		if len(key)-pos < len(n.Key) || !bytes.Equal(n.Key, key[pos:pos+len(n.Key)]) {
+			// key not found in trie
+			return nil, n, false, nil
+		}
+		value, newnode, didResolve, err = t.getWithEpoch(n.Val, key, pos+len(n.Key), epoch)
+		if err == nil && t.renewNode(epoch, didResolve, true) {
+			n = n.copy()
+			n.Val = newnode
+			n.setEpoch(t.getRootEpoch())
+		}
+		return value, n, didResolve, err
+	case *fullNode:
+		value, newnode, didResolve, err = t.getWithEpoch(n.Children[key[pos]], key, pos+1, n.GetChildEpoch(int(key[pos])))
+		if err == nil && t.renewNode(epoch, didResolve, true) {
+			n = n.copy()
+			n.Children[key[pos]] = newnode
+			n.setEpoch(t.getRootEpoch())
+			n.UpdateChildEpoch(int(key[pos]), t.getRootEpoch())
+		}
+		return value, n, didResolve, err
+	case hashNode:
+		child, err := t.resolveAndTrack(n, key[:pos])
+		if err != nil {
+			return nil, n, true, err
+		}
+
+		if child, ok := child.(*fullNode); ok {
+			epochMap, err := t.resolveMeta(child, epoch, key[:pos])
+			if err != nil {
+				return nil, n, true, err
+			}
+			child.SetEpochMap(epochMap)
+		}
+		value, newnode, _, err := t.getWithEpoch(child, key, pos, epoch)
 		return value, newnode, true, err
 	default:
 		panic(fmt.Sprintf("%T: invalid node: %v", origNode, origNode))
@@ -304,6 +398,10 @@ func (t *Trie) Update(key, value []byte) error {
 	if t.committed {
 		return ErrCommitted
 	}
+
+	if t.enableExpiry {
+		return t.updateWithEpoch(key, value, t.getRootEpoch())
+	}
 	return t.update(key, value)
 }
 
@@ -318,6 +416,25 @@ func (t *Trie) update(key, value []byte) error {
 		t.root = n
 	} else {
 		_, n, err := t.delete(t.root, nil, k)
+		if err != nil {
+			return err
+		}
+		t.root = n
+	}
+	return nil
+}
+
+func (t *Trie) updateWithEpoch(key, value []byte, epoch types.StateEpoch) error {
+	t.unhashed++
+	k := keybytesToHex(key)
+	if len(value) != 0 {
+		_, n, err := t.insertWithEpoch(t.root, nil, k, valueNode(value), epoch)
+		if err != nil {
+			return err
+		}
+		t.root = n
+	} else {
+		_, n, err := t.deleteWithEpoch(t.root, nil, k, epoch)
 		if err != nil {
 			return err
 		}
@@ -343,7 +460,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 			if !dirty || err != nil {
 				return false, n, err
 			}
-			return true, &shortNode{n.Key, nn, t.newFlag()}, nil
+			return true, &shortNode{Key: n.Key, Val: nn, flags: t.newFlag()}, nil
 		}
 		// Otherwise branch out at the index where they differ.
 		branch := &fullNode{flags: t.newFlag()}
@@ -366,7 +483,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 		t.tracer.onInsert(append(prefix, key[:matchlen]...))
 
 		// Replace it with a short node leading up to the branch.
-		return true, &shortNode{key[:matchlen], branch, t.newFlag()}, nil
+		return true, &shortNode{Key: key[:matchlen], Val: branch, flags: t.newFlag()}, nil
 
 	case *fullNode:
 		dirty, nn, err := t.insert(n.Children[key[0]], append(prefix, key[0]), key[1:], value)
@@ -384,7 +501,7 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 		// since it's always embedded in its parent.
 		t.tracer.onInsert(prefix)
 
-		return true, &shortNode{key, value, t.newFlag()}, nil
+		return true, &shortNode{Key: key, Val: value, flags: t.newFlag()}, nil
 
 	case hashNode:
 		// We've hit a part of the trie that isn't loaded yet. Load
@@ -396,6 +513,103 @@ func (t *Trie) insert(n node, prefix, key []byte, value node) (bool, node, error
 		}
 		dirty, nn, err := t.insert(rn, prefix, key, value)
 		if !dirty || err != nil {
+			return false, rn, err
+		}
+		return true, nn, nil
+
+	default:
+		panic(fmt.Sprintf("%T: invalid node: %v", n, n))
+	}
+}
+
+func (t *Trie) insertWithEpoch(n node, prefix, key []byte, value node, epoch types.StateEpoch) (bool, node, error) {
+	if t.epochExpired(n, epoch) {
+		return false, nil, NewExpiredNodeError(prefix, epoch)
+	}
+
+	if len(key) == 0 {
+		if v, ok := n.(valueNode); ok {
+			return !bytes.Equal(v, value.(valueNode)), value, nil
+		}
+		return true, value, nil
+	}
+	switch n := n.(type) {
+	case *shortNode:
+		matchlen := prefixLen(key, n.Key)
+		// If the whole key matches, keep this short node as is
+		// and only update the value.
+		if matchlen == len(n.Key) {
+			dirty, nn, err := t.insertWithEpoch(n.Val, append(prefix, key[:matchlen]...), key[matchlen:], value, epoch)
+			if !t.renewNode(epoch, dirty, true) || err != nil {
+				return false, n, err
+			}
+			return true, &shortNode{Key: n.Key, Val: nn, flags: t.newFlag(), epoch: epoch}, nil
+		}
+		// Otherwise branch out at the index where they differ.
+		branch := &fullNode{flags: t.newFlag(), epoch: epoch}
+		var err error
+		_, branch.Children[n.Key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, n.Key[:matchlen+1]...), n.Key[matchlen+1:], n.Val, epoch)
+		if err != nil {
+			return false, nil, err
+		}
+		branch.UpdateChildEpoch(int(n.Key[matchlen]), epoch)
+
+		_, branch.Children[key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, key[:matchlen+1]...), key[matchlen+1:], value, epoch)
+		if err != nil {
+			return false, nil, err
+		}
+		branch.UpdateChildEpoch(int(key[matchlen]), epoch)
+
+		// Replace this shortNode with the branch if it occurs at index 0.
+		if matchlen == 0 {
+			return true, branch, nil
+		}
+		// New branch node is created as a child of the original short node.
+		// Track the newly inserted node in the tracer. The node identifier
+		// passed is the path from the root node.
+		t.tracer.onInsert(append(prefix, key[:matchlen]...))
+
+		// Replace it with a short node leading up to the branch.
+		return true, &shortNode{Key: key[:matchlen], Val: branch, flags: t.newFlag(), epoch: epoch}, nil
+
+	case *fullNode:
+		dirty, nn, err := t.insertWithEpoch(n.Children[key[0]], append(prefix, key[0]), key[1:], value, n.GetChildEpoch(int(key[0])))
+		if !dirty || err != nil {
+			return false, n, err
+		}
+		n = n.copy()
+		n.flags = t.newFlag()
+		n.Children[key[0]] = nn
+		return true, n, nil
+
+	case nil:
+		// New short node is created and track it in the tracer. The node identifier
+		// passed is the path from the root node. Note the valueNode won't be tracked
+		// since it's always embedded in its parent.
+		t.tracer.onInsert(prefix)
+
+		return true, &shortNode{Key: key, Val: value, flags: t.newFlag(), epoch: epoch}, nil
+
+	case hashNode:
+		// We've hit a part of the trie that isn't loaded yet. Load
+		// the node and insert into it. This leaves all child nodes on
+		// the path to the value in the trie.
+		rn, err := t.resolveAndTrack(n, prefix)
+		if err != nil {
+			return false, nil, err
+		}
+
+		// TODO(asyukii): if resolved node is a full node, then resolve epochMap as well
+		if child, ok := rn.(*fullNode); ok {
+			epochMap, err := t.resolveMeta(child, epoch, prefix)
+			if err != nil {
+				return false, nil, err
+			}
+			child.SetEpochMap(epochMap)
+		}
+
+		dirty, nn, err := t.insertWithEpoch(rn, prefix, key, value, epoch)
+		if !t.renewNode(epoch, dirty, true) || err != nil {
 			return false, rn, err
 		}
 		return true, nn, nil
@@ -418,13 +632,21 @@ func (t *Trie) MustDelete(key []byte) {
 // If the requested node is not present in trie, no error will be returned.
 // If the trie is corrupted, a MissingNodeError is returned.
 func (t *Trie) Delete(key []byte) error {
+	var n node
+	var err error
 	// Short circuit if the trie is already committed and not usable.
 	if t.committed {
 		return ErrCommitted
 	}
 	t.unhashed++
 	k := keybytesToHex(key)
-	_, n, err := t.delete(t.root, nil, k)
+
+	if t.enableExpiry {
+		_, n, err = t.deleteWithEpoch(t.root, nil, k, t.getRootEpoch())
+	} else {
+		_, n, err = t.delete(t.root, nil, k)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -470,9 +692,9 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 			// always creates a new slice) instead of append to
 			// avoid modifying n.Key since it might be shared with
 			// other nodes.
-			return true, &shortNode{concat(n.Key, child.Key...), child.Val, t.newFlag()}, nil
+			return true, &shortNode{Key: concat(n.Key, child.Key...), Val: child.Val, flags: t.newFlag()}, nil
 		default:
-			return true, &shortNode{n.Key, child, t.newFlag()}, nil
+			return true, &shortNode{Key: n.Key, Val: child, flags: t.newFlag()}, nil
 		}
 
 	case *fullNode:
@@ -531,12 +753,12 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 					t.tracer.onDelete(append(prefix, byte(pos)))
 
 					k := append([]byte{byte(pos)}, cnode.Key...)
-					return true, &shortNode{k, cnode.Val, t.newFlag()}, nil
+					return true, &shortNode{Key: k, Val: cnode.Val, flags: t.newFlag()}, nil
 				}
 			}
 			// Otherwise, n is replaced by a one-nibble short node
 			// containing the child.
-			return true, &shortNode{[]byte{byte(pos)}, n.Children[pos], t.newFlag()}, nil
+			return true, &shortNode{Key: []byte{byte(pos)}, Val: n.Children[pos], flags: t.newFlag()}, nil
 		}
 		// n still contains at least two values and cannot be reduced.
 		return true, n, nil
@@ -566,6 +788,151 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 	}
 }
 
+func (t *Trie) deleteWithEpoch(n node, prefix, key []byte, epoch types.StateEpoch) (bool, node, error) {
+	if t.epochExpired(n, epoch) {
+		return false, nil, NewExpiredNodeError(prefix, epoch)
+	}
+
+	switch n := n.(type) {
+	case *shortNode:
+		matchlen := prefixLen(key, n.Key)
+		if matchlen < len(n.Key) {
+			return false, n, nil // don't replace n on mismatch
+		}
+		if matchlen == len(key) {
+			// The matched short node is deleted entirely and track
+			// it in the deletion set. The same the valueNode doesn't
+			// need to be tracked at all since it's always embedded.
+			t.tracer.onDelete(prefix)
+
+			return true, nil, nil // remove n entirely for whole matches
+		}
+		// The key is longer than n.Key. Remove the remaining suffix
+		// from the subtrie. Child can never be nil here since the
+		// subtrie must contain at least two other values with keys
+		// longer than n.Key.
+		dirty, child, err := t.deleteWithEpoch(n.Val, append(prefix, key[:len(n.Key)]...), key[len(n.Key):], epoch)
+		if !t.renewNode(epoch, dirty, true) || err != nil {
+			return false, n, err
+		}
+		switch child := child.(type) {
+		case *shortNode:
+			// The child shortNode is merged into its parent, track
+			// is deleted as well.
+			t.tracer.onDelete(append(prefix, n.Key...))
+
+			// Deleting from the subtrie reduced it to another
+			// short node. Merge the nodes to avoid creating a
+			// shortNode{..., shortNode{...}}. Use concat (which
+			// always creates a new slice) instead of append to
+			// avoid modifying n.Key since it might be shared with
+			// other nodes.
+			return true, &shortNode{Key: concat(n.Key, child.Key...), Val: child.Val, flags: t.newFlag(), epoch: epoch}, nil
+		default:
+			return true, &shortNode{Key: n.Key, Val: child, flags: t.newFlag(), epoch: epoch}, nil
+		}
+
+	case *fullNode:
+		dirty, nn, err := t.deleteWithEpoch(n.Children[key[0]], append(prefix, key[0]), key[1:], n.GetChildEpoch(int(key[0])))
+		if !t.renewNode(epoch, dirty, true) || err != nil {
+			return false, n, err
+		}
+		n = n.copy()
+		n.flags = t.newFlag()
+		n.Children[key[0]] = nn
+
+		// Because n is a full node, it must've contained at least two children
+		// before the delete operation. If the new child value is non-nil, n still
+		// has at least two children after the deletion, and cannot be reduced to
+		// a short node.
+		if nn != nil {
+			return true, n, nil
+		}
+		// Reduction:
+		// Check how many non-nil entries are left after deleting and
+		// reduce the full node to a short node if only one entry is
+		// left. Since n must've contained at least two children
+		// before deletion (otherwise it would not be a full node) n
+		// can never be reduced to nil.
+		//
+		// When the loop is done, pos contains the index of the single
+		// value that is left in n or -2 if n contains at least two
+		// values.
+		pos := -1
+		for i, cld := range &n.Children {
+			if cld != nil {
+				if pos == -1 {
+					pos = i
+				} else {
+					pos = -2
+					break
+				}
+			}
+		}
+		if pos >= 0 {
+			if pos != 16 {
+				// If the remaining entry is a short node, it replaces
+				// n and its key gets the missing nibble tacked to the
+				// front. This avoids creating an invalid
+				// shortNode{..., shortNode{...}}.  Since the entry
+				// might not be loaded yet, resolve it just for this
+				// check.
+				cnode, err := t.resolve(n.Children[pos], append(prefix, byte(pos)))
+				if err != nil {
+					return false, nil, err
+				}
+				if cnode, ok := cnode.(*shortNode); ok {
+					// Replace the entire full node with the short node.
+					// Mark the original short node as deleted since the
+					// value is embedded into the parent now.
+					t.tracer.onDelete(append(prefix, byte(pos)))
+
+					k := append([]byte{byte(pos)}, cnode.Key...)
+					return true, &shortNode{Key: k, Val: cnode.Val, flags: t.newFlag()}, nil
+				}
+			}
+			// Otherwise, n is replaced by a one-nibble short node
+			// containing the child.
+			return true, &shortNode{Key: []byte{byte(pos)}, Val: n.Children[pos], flags: t.newFlag(), epoch: epoch}, nil
+		}
+		// n still contains at least two values and cannot be reduced.
+		return true, n, nil
+
+	case valueNode:
+		return true, nil, nil
+
+	case nil:
+		return false, nil, nil
+
+	case hashNode:
+		// We've hit a part of the trie that isn't loaded yet. Load
+		// the node and delete from it. This leaves all child nodes on
+		// the path to the value in the trie.
+		rn, err := t.resolveAndTrack(n, prefix)
+		if err != nil {
+			return false, nil, err
+		}
+
+		if child, ok := rn.(*fullNode); ok {
+			epochMap, err := t.resolveMeta(child, epoch, prefix)
+			if err != nil {
+				return false, nil, err
+			}
+			child.SetEpochMap(epochMap)
+		}
+
+		dirty, nn, err := t.deleteWithEpoch(rn, prefix, key, epoch)
+		if !dirty || err != nil {
+			return false, rn, err
+		}
+		return true, nn, nil
+
+	default:
+		panic(fmt.Sprintf("%T: invalid node: %v (%v)", n, n, key))
+	}
+
+}
+
 func concat(s1 []byte, s2 ...byte) []byte {
 	r := make([]byte, len(s1)+len(s2))
 	copy(r, s1)
@@ -591,6 +958,12 @@ func (t *Trie) resolveAndTrack(n hashNode, prefix []byte) (node, error) {
 	}
 	t.tracer.onRead(prefix, blob)
 	return mustDecodeNode(n, blob), nil
+}
+
+// TODO(asyukii): implement resolve full node's epoch map.
+func (t *Trie) resolveMeta(n node, epoch types.StateEpoch, prefix []byte) ([16]types.StateEpoch, error) {
+	// 1. Check if the node is a full node
+	panic("implement me!")
 }
 
 // Hash returns the root hash of the trie. It does not write to the
@@ -672,29 +1045,38 @@ func (t *Trie) Reset() {
 }
 
 // ReviveTrie revives a trie by prefix key with the given proof list.
-func (t *Trie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) {
+func (t *Trie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) error {
+
 	key = keybytesToHex(key)
 
 	// Verify the proof first
-	revivedNode, revivedHash, err := VerifyPathProof(key, prefixKeyHex, proofList)
+	revivedNode, revivedHash, err := VerifyPathProof(key, prefixKeyHex, proofList, t.getRootEpoch())
 	if err != nil {
-		log.Error("Failed to verify proof", "err", err)
+		return err
 	}
 
-	newRoot, _, err := t.revive(t.root, key, prefixKeyHex, 0, revivedNode, common.BytesToHash(revivedHash))
+	newRoot, _, err := t.revive(t.root, key, prefixKeyHex, 0, revivedNode, common.BytesToHash(revivedHash), t.getRootEpoch(), false)
 	if err != nil {
-		log.Error("Failed to revive trie", "err", err)
+		return err
 	}
+
 	t.root = newRoot
+
+	return nil
 }
 
-func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedNode node, revivedHash common.Hash) (node, bool, error) {
+func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedNode node, revivedHash common.Hash, epoch types.StateEpoch, isExpired bool) (node, bool, error) {
 
 	if pos > len(prefixKeyHex) {
 		return nil, false, fmt.Errorf("target revive node not found")
 	}
 
 	if pos == len(prefixKeyHex) {
+
+		if !isExpired {
+			return nil, false, fmt.Errorf("target revive node is not expired")
+		}
+
 		hn, ok := n.(hashNode)
 		if !ok {
 			return nil, false, fmt.Errorf("prefix key path does not lead to a hash node")
@@ -708,24 +1090,32 @@ func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedN
 		return revivedNode, true, nil
 	}
 
+	if isExpired {
+		return nil, false, NewExpiredNodeError(key[:pos], epoch)
+	}
+
 	switch n := n.(type) {
 	case *shortNode:
 		if len(key)-pos < len(n.Key) || !bytes.Equal(n.Key, key[pos:pos+len(n.Key)]) {
 			// key not found in trie
 			return n, false, nil
 		}
-		newNode, didRevived, err := t.revive(n.Val, key, prefixKeyHex, pos+len(n.Key), revivedNode, revivedHash)
+		newNode, didRevived, err := t.revive(n.Val, key, prefixKeyHex, pos+len(n.Key), revivedNode, revivedHash, epoch, isExpired)
 		if err == nil && didRevived {
 			n = n.copy()
 			n.Val = newNode
+			n.setEpoch(t.getRootEpoch())
 		}
 		return n, didRevived, err
 	case *fullNode:
 		childIndex := int(key[pos])
-		newNode, didRevived, err := t.revive(n.Children[childIndex], key, prefixKeyHex, pos+1, revivedNode, revivedHash)
+		childExpired, _ := n.ChildExpired(key[:pos], childIndex, t.getRootEpoch())
+		newNode, didRevived, err := t.revive(n.Children[childIndex], key, prefixKeyHex, pos+1, revivedNode, revivedHash, n.GetChildEpoch(childIndex), childExpired)
 		if err == nil && didRevived {
 			n = n.copy()
 			n.Children[key[pos]] = newNode
+			n.setEpoch(t.getRootEpoch())
+			n.UpdateChildEpoch(childIndex, t.getRootEpoch())
 		}
 		return n, didRevived, err
 	case hashNode:
@@ -733,7 +1123,16 @@ func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedN
 		if err != nil {
 			return nil, false, err
 		}
-		newNode, _, err := t.revive(child, key, prefixKeyHex, pos, revivedNode, revivedHash)
+
+		if child, ok := child.(*fullNode); ok {
+			epochMap, err := t.resolveMeta(child, epoch, key[:pos])
+			if err != nil {
+				return nil, false, err
+			}
+			child.SetEpochMap(epochMap)
+		}
+
+		newNode, _, err := t.revive(child, key, prefixKeyHex, pos, revivedNode, revivedHash, epoch, isExpired)
 		return newNode, true, err
 	case nil:
 		return nil, false, nil
@@ -746,7 +1145,7 @@ func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedN
 // It is not used in the actual trie implementation. ExpireByPrefix makes sure
 // only a child node of a full node is expired, if not an error is returned.
 func (t *Trie) ExpireByPrefix(prefixKeyHex []byte) error {
-	hn, err := t.expireByPrefix(t.root, prefixKeyHex)
+	hn, _, err := t.expireByPrefix(t.root, prefixKeyHex)
 	if prefixKeyHex == nil && hn != nil {
 		t.root = hn
 	}
@@ -756,41 +1155,42 @@ func (t *Trie) ExpireByPrefix(prefixKeyHex []byte) error {
 	return nil
 }
 
-func (t *Trie) expireByPrefix(n node, prefixKeyHex []byte) (node, error) {
+func (t *Trie) expireByPrefix(n node, prefixKeyHex []byte) (node, bool, error) {
 	// Loop through prefix key
 	// When prefix key is empty, generate the hash node of the current node
 	// Replace current node with the hash node
 
+	// If length of prefix key is empty
 	if len(prefixKeyHex) == 0 {
 		hasher := newHasher(false)
 		defer returnHasherToPool(hasher)
 		var hn node
 		_, hn = hasher.proofHash(n)
 		if _, ok := hn.(hashNode); ok {
-			return hn, nil
+			return hn, false, nil
 		}
 
-		return nil, nil
+		return nil, true, nil
 	}
 
 	switch n := n.(type) {
 	case *shortNode:
 		matchLen := prefixLen(prefixKeyHex, n.Key)
-		hn, err := t.expireByPrefix(n.Val, prefixKeyHex[matchLen:])
+		hn, didUpdateEpoch, err := t.expireByPrefix(n.Val, prefixKeyHex[matchLen:])
 		if err != nil {
-			return nil, err
+			return nil, didUpdateEpoch, err
 		}
 
 		if hn != nil {
-			return nil, fmt.Errorf("can only expire child short node")
+			return nil, didUpdateEpoch, fmt.Errorf("can only expire child short node")
 		}
 
-		return nil, err
+		return nil, didUpdateEpoch, err
 	case *fullNode:
 		childIndex := int(prefixKeyHex[0])
-		hn, err := t.expireByPrefix(n.Children[childIndex], prefixKeyHex[1:])
+		hn, didUpdateEpoch, err := t.expireByPrefix(n.Children[childIndex], prefixKeyHex[1:])
 		if err != nil {
-			return nil, err
+			return nil, didUpdateEpoch, err
 		}
 
 		// Replace child node with hash node
@@ -798,8 +1198,43 @@ func (t *Trie) expireByPrefix(n node, prefixKeyHex []byte) (node, error) {
 			n.Children[prefixKeyHex[0]] = hn
 		}
 
-		return nil, err
+		// Update the epoch so that it is expired
+		if !didUpdateEpoch {
+			n.UpdateChildEpoch(childIndex, 0)
+			didUpdateEpoch = true
+		}
+
+		return nil, didUpdateEpoch, err
 	default:
-		return nil, fmt.Errorf("invalid node type")
+		return nil, false, fmt.Errorf("invalid node type")
 	}
+}
+
+func (t *Trie) getRootEpoch() types.StateEpoch {
+	return t.rootEpoch
+}
+
+// renewNode check if renew node, according to trie node epoch and childDirty,
+// childDirty or updateEpoch need copy for prevent reuse trie cache
+func (t *Trie) renewNode(epoch types.StateEpoch, childDirty bool, updateEpoch bool) bool {
+	// when !updateEpoch, it same as !t.withShadowNodes
+	if !t.enableExpiry || !updateEpoch {
+		return childDirty
+	}
+
+	// when no epoch update, same as before
+	if epoch == t.getRootEpoch() {
+		return childDirty
+	}
+
+	// node need update epoch, just renew
+	return true
+}
+
+func (t *Trie) epochExpired(n node, epoch types.StateEpoch) bool {
+	// when node is nil, skip epoch check
+	if !t.enableExpiry || n == nil {
+		return false
+	}
+	return types.EpochExpired(epoch, t.getRootEpoch())
 }


### PR DESCRIPTION
**Description**
Add a feature to create Trie with state expiry features, where nodes are epoch-based and can be expired.

Add eth_getStorageReviveProof RPC method to retrieve proof from keys and prefix keys. This RPC method supports the retrieval proofs of multiple keys.

**Changes**
- fullNode has extra field `EpochMap`
- fullNode and shortNode have extra field `epoch` for cache purposes
- CRUD and revive operation on Trie nodes will update epochs accordingly
- Add new error type `ExpiredNodeError`
- Trie interface has an additional function ProvePath
- Add functions to support RPC features
- Add UT