### PR TITLE
feat: add eth_getStorageReviveProof

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -130,6 +130,8 @@ type Trie interface {
 	// nodes of the longest existing prefix of the key (at least the root), ending
 	// with the node that proves the absence of the key.
 	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
+
+	ProvePath(key []byte, path []byte, proofDb ethdb.KeyValueWriter) error
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -78,6 +78,12 @@ type StorageResult struct {
 	Proof []string `json:"proof"`
 }
 
+type ReviveStorageResult struct {
+	Key       string   `json:"key"`
+	PrefixKey string   `json:"prefixKey"`
+	Proof     []string `json:"proof"`
+}
+
 // GetProof returns the account and storage values of the specified account including the Merkle-proof.
 // The block number can be nil, in which case the value is taken from the latest known block.
 func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []string, blockNumber *big.Int) (*AccountResult, error) {
@@ -123,6 +129,20 @@ func (ec *Client) GetProof(ctx context.Context, account common.Address, keys []s
 		StorageProof: storageResults,
 	}
 	return &result, err
+}
+
+// GetStorageReviveProof returns the proof for the given keys. Prefix keys can be specified to obtain partial proof for a given key.
+// Both keys and prefix keys should have the same length. If user wish to obtain full proof for a given key, the corresponding prefix key should be empty string.
+func (ec *Client) GetStorageReviveProof(ctx context.Context, account common.Address, keys []string, prefixKeys []string, blockNumber *big.Int) ([]ReviveStorageResult, error) {
+
+	storageResults := make([]ReviveStorageResult, 0, len(keys))
+
+	if len(keys) != len(prefixKeys) {
+		return nil, fmt.Errorf("keys and prefixKeys must be same length")
+	}
+
+	err := ec.c.CallContext(ctx, &storageResults, "eth_getStorageReviveProof", account, keys, prefixKeys, toBlockNumArg(blockNumber))
+	return storageResults, err
 }
 
 // CallContract executes a message call transaction, which is directly executed in the VM

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -106,6 +106,9 @@ func TestGethClient(t *testing.T) {
 			"TestGetProof",
 			func(t *testing.T) { testGetProof(t, client) },
 		}, {
+			"TestGetStorageReviveProof",
+			func(t *testing.T) { testGetStorageReviveProof(t, client) },
+		}, {
 			"TestGetProofCanonicalizeKeys",
 			func(t *testing.T) { testGetProofCanonicalizeKeys(t, client) },
 		}, {
@@ -233,6 +236,27 @@ func testGetProof(t *testing.T, client *rpc.Client) {
 	}
 	if proof.Key != testSlot.String() {
 		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), proof.Key)
+	}
+}
+
+func testGetStorageReviveProof(t *testing.T, client *rpc.Client) {
+	ec := New(client)
+	result, err := ec.GetStorageReviveProof(context.Background(), testAddr, []string{testSlot.String()}, []string{""}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// test storage
+	if len(result) != 1 {
+		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(result))
+	}
+
+	if result[0].Key != testSlot.String() {
+		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), result[0].Key)
+	}
+
+	if result[0].PrefixKey != "" {
+		t.Fatalf("invalid storage proof prefix key, want: %q, got: %q", "", result[0].PrefixKey)
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -655,6 +655,12 @@ type StorageResult struct {
 	Proof []string     `json:"proof"`
 }
 
+type ReviveStorageResult struct {
+	Key       string   `json:"key"`
+	PrefixKey string   `json:"prefixKey"`
+	Proof     []string `json:"proof"`
+}
+
 // proofList implements ethdb.KeyValueWriter and collects the proofs as
 // hex-strings for delivery to rpc-caller.
 type proofList []string
@@ -741,6 +747,76 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 		StorageHash:  storageHash,
 		StorageProof: storageProof,
 	}, state.Error()
+}
+
+// GetStorageReviveProof returns the proof for the given keys. Prefix keys can be specified to obtain partial proof for a given key.
+// Both keys and prefix keys should have the same length. If user wish to obtain full proof for a given key, the corresponding prefix key should be empty string.
+func (s *BlockChainAPI) GetStorageReviveProof(ctx context.Context, address common.Address, storageKeys []string, storagePrefixKeys []string, blockNrOrHash rpc.BlockNumberOrHash) ([]ReviveStorageResult, error) {
+
+	if len(storageKeys) != len(storagePrefixKeys) {
+		return nil, errors.New("storageKeys and storagePrefixKeys must be same length")
+	}
+
+	var (
+		keys         = make([]common.Hash, len(storageKeys))
+		keyLengths   = make([]int, len(storageKeys))
+		prefixKeys   = make([][]byte, len(storagePrefixKeys))
+		storageProof = make([]ReviveStorageResult, len(storageKeys))
+		storageTrie  state.Trie
+	)
+	// Deserialize all keys. This prevents state access on invalid input.
+	for i, hexKey := range storageKeys {
+		var err error
+		keys[i], keyLengths[i], err = decodeHash(hexKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Decode prefix keys
+	for i, prefixKey := range storagePrefixKeys {
+		var err error
+		prefixKeys[i], err = hex.DecodeString(prefixKey)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
+	if state == nil || err != nil {
+		return nil, err
+	}
+	if storageTrie, err = state.StorageTrie(address); err != nil {
+		return nil, err
+	}
+
+	// Must have storage trie
+	if storageTrie == nil {
+		return nil, errors.New("storageTrie is nil")
+	}
+
+	// Create the proofs for the storageKeys.
+	for i, key := range keys {
+		// Output key encoding is a bit special: if the input was a 32-byte hash, it is
+		// returned as such. Otherwise, we apply the QUANTITY encoding mandated by the
+		// JSON-RPC spec for getProof. This behavior exists to preserve backwards
+		// compatibility with older client versions.
+		var outputKey string
+		if keyLengths[i] != 32 {
+			outputKey = hexutil.EncodeBig(key.Big())
+		} else {
+			outputKey = hexutil.Encode(key[:])
+		}
+
+		var proof proofList
+		prefixKey := prefixKeys[i]
+		if err := storageTrie.ProvePath(crypto.Keccak256(key.Bytes()), prefixKey, &proof); err != nil {
+			return nil, err
+		}
+		storageProof[i] = ReviveStorageResult{outputKey, storagePrefixKeys[i], proof}
+	}
+
+	return storageProof, nil
 }
 
 // decodeHash parses a hex-encoded 32-byte hash. The input may optionally

--- a/light/trie.go
+++ b/light/trie.go
@@ -203,6 +203,10 @@ func (t *odrTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 	return errors.New("not implemented, needs client/server interface split")
 }
 
+func (t *odrTrie) ProvePath(key []byte, path []byte, proofDb ethdb.KeyValueWriter) error {
+	return errors.New("not implemented, needs client/server interface split")
+}
+
 // do tries and retries to execute a function until it returns with no error or
 // an error type other than MissingNodeError
 func (t *odrTrie) do(key []byte, fn func() error) error {


### PR DESCRIPTION
**Description**
Add eth_getStorageReviveProof RPC method to retrieve proof from keys and prefix keys. This RPC method supports the retrieval proofs of multiple keys.

**Change**
- Trie interface has an additional function `ProvePath`
- Add functions to support RPC features
- Add UT