### PR TITLE
core/state, core/types, trie: impl. revive storage trie, modify metadata type, add trie.currentEpoch

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -75,6 +75,8 @@ type Trie interface {
 	// a trie.MissingNodeError is returned.
 	GetStorage(addr common.Address, key []byte) ([]byte, error)
 
+	GetStorageAndUpdateEpoch(addr common.Address, key []byte) ([]byte, error)
+
 	// GetAccount abstracts an account read from the trie. It retrieves the
 	// account blob from the trie with provided account address and decodes it
 	// with associated decoding algorithm. If the specified account is not in

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -132,6 +132,8 @@ type Trie interface {
 	Prove(key []byte, proofDb ethdb.KeyValueWriter) error
 
 	ProvePath(key []byte, path []byte, proofDb ethdb.KeyValueWriter) error
+
+	ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) error
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -278,7 +278,7 @@ func (s *stateObject) GetCommittedState(key common.Hash) common.Hash {
 			s.db.setError(err)
 			return common.Hash{}
 		}
-		val, err := tr.GetStorage(s.address, key.Bytes())
+		val, err := tr.GetStorageAndUpdateEpoch(s.address, key.Bytes())
 		if metrics.EnabledExpensive {
 			s.db.StorageReads += time.Since(start)
 		}
@@ -751,7 +751,7 @@ func (s *stateObject) ReviveStorageTrie(proof types.ReviveStorageProof) error {
 	}
 
 	// Update pending revive state
-	val, err := dr.GetStorage(s.address, key) // TODO(asyukii): may optimize this, return value when revive trie
+	val, err := dr.GetStorageAndUpdateEpoch(s.address, key) // TODO(asyukii): may optimize this, return value when revive trie
 	if err != nil {
 		return fmt.Errorf("get storage value failed, err: %v", err)
 	}

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -730,32 +730,35 @@ func (s *stateObject) Nonce() uint64 {
 	return s.data.Nonce
 }
 
-// ReviveStorageTrie TODO(0xbundler): combine with trie
-//func (s *stateObject) ReviveStorageTrie(proofCache trie.MPTProofCache) error {
-//	dr := s.getDirtyReviveTrie(s.db.db)
-//	s.db.journal.append(reviveStorageTrieNodeChange{
-//		address: &s.address,
-//	})
-//	// revive nub and cache revive state TODO(0xbundler): support proofs merge, revive in nubs
-//	for _, nub := range dr.ReviveTrie(proofCache.CacheNubs()) {
-//		kv, err := nub.ResolveKV()
-//		if err != nil {
-//			return err
-//		}
-//		for k, enc := range kv {
-//			var value common.Hash
-//			if len(enc) > 0 {
-//				_, content, _, err := rlp.Split(enc)
-//				if err != nil {
-//					return err
-//				}
-//				value.SetBytes(content)
-//			}
-//			s.dirtyReviveState[k] = value
-//		}
-//	}
-//	return nil
-//}
+func (s *stateObject) ReviveStorageTrie(proof types.ReviveStorageProof) error {
+	dr, err := s.getPendingReviveTrie()
+	if err != nil {
+		return err
+	}
+
+	key := common.Hex2Bytes(proof.Key)
+	prefixKey := common.Hex2Bytes(proof.PrefixKey)
+	proofList := make([][]byte, 0, len(proof.Proof))
+
+	for _, p := range proof.Proof {
+		proofList = append(proofList, common.Hex2Bytes(p))
+	}
+
+	// TODO(asyukii): support proofs merge, revive in nubs
+	err = dr.ReviveTrie(crypto.Keccak256(key), prefixKey, proofList)
+	if err != nil {
+		return fmt.Errorf("revive storage trie failed, err: %v", err)
+	}
+
+	// Update pending revive state
+	val, err := dr.GetStorage(s.address, key) // TODO(asyukii): may optimize this, return value when revive trie
+	if err != nil {
+		return fmt.Errorf("get storage value failed, err: %v", err)
+	}
+
+	s.pendingReviveState[proof.Key] = common.BytesToHash(val)
+	return nil
+}
 
 // accessState record all access states, now in pendingAccessedStateEpoch without consensus
 func (s *stateObject) accessState(key common.Hash) {

--- a/core/types/meta.go
+++ b/core/types/meta.go
@@ -1,23 +1,44 @@
 package types
 
 import (
+	"errors"
+
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
+const (
+	MetaNoConsensusType = iota
+)
+
+var (
+	ErrMetaNotSupport = errors.New("the meta type not support now")
+)
+
+type MetaNoConsensus StateEpoch // Represents the epoch number
+
 type StateMeta interface {
-	GetVersionNumber() uint8
+	GetType() byte
 	Hash() common.Hash
+	EncodeToRLPBytes() ([]byte, error)
 }
 
-type MetaNoConsensus struct {
-	Version uint8
-	Epoch   uint16
+func NewMetaNoConsensus(epoch StateEpoch) StateMeta {
+	return MetaNoConsensus(epoch)
 }
 
-func (m *MetaNoConsensus) GetVersionNumber() uint8 {
-	return m.Version
+func (m MetaNoConsensus) GetType() byte {
+	return MetaNoConsensusType
 }
 
-func (m *MetaNoConsensus) Hash() common.Hash {
-	return rlpHash(m.Epoch)
+func (m MetaNoConsensus) Hash() common.Hash {
+	return common.Hash{}
+}
+
+func (m MetaNoConsensus) EncodeToRLPBytes() ([]byte, error) {
+	enc, err := rlp.EncodeToBytes(m)
+	if err != nil {
+		return nil, err
+	}
+	return enc, nil
 }

--- a/core/types/revive_state.go
+++ b/core/types/revive_state.go
@@ -1,0 +1,7 @@
+package types
+
+type ReviveStorageProof struct {
+	Key       string   `json:"key"`
+	PrefixKey string   `json:"prefixKey"`
+	Proof     []string `json:"proof"`
+}

--- a/light/trie.go
+++ b/light/trie.go
@@ -106,6 +106,10 @@ type odrTrie struct {
 	trie *trie.Trie
 }
 
+func (t *odrTrie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) error {
+	panic("not implemented")
+}
+
 func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	key = crypto.Keccak256(key)
 	var enc []byte

--- a/light/trie.go
+++ b/light/trie.go
@@ -124,6 +124,10 @@ func (t *odrTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	return content, err
 }
 
+func (t *odrTrie) GetStorageAndUpdateEpoch(_ common.Address, key []byte) ([]byte, error) {
+	panic("not implemented")
+}
+
 func (t *odrTrie) GetAccount(address common.Address) (*types.StateAccount, error) {
 	var (
 		enc []byte

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -94,6 +94,15 @@ func (t *StateTrie) GetStorage(_ common.Address, key []byte) ([]byte, error) {
 	return content, err
 }
 
+func (t *StateTrie) GetStorageAndUpdateEpoch(addr common.Address, key []byte) ([]byte, error) {
+	enc, err := t.trie.GetAndUpdateEpoch(t.hashKey(key))
+	if err != nil || len(enc) == 0 {
+		return nil, err
+	}
+	_, content, _, err := rlp.Split(enc)
+	return content, err
+}
+
 // GetAccount attempts to retrieve an account with provided account address.
 // If the specified account is not in the trie, nil will be returned.
 // If a trie node is not found in the database, a MissingNodeError is returned.

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -288,3 +288,7 @@ func (t *StateTrie) getSecKeyCache() map[string][]byte {
 	}
 	return t.secKeyCache
 }
+
+func (t *StateTrie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) error {
+	return t.trie.ReviveTrie(key, prefixKeyHex, proofList)
+}

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -56,6 +56,7 @@ type Trie struct {
 	tracer *tracer
 
 	// fields for state expiry
+	currentEpoch types.StateEpoch
 	rootEpoch    types.StateEpoch
 	enableExpiry bool
 }
@@ -186,10 +187,23 @@ func (t *Trie) Get(key []byte) (value []byte, err error) {
 	}
 
 	if t.enableExpiry {
-		value, newroot, didResolve, err = t.getWithEpoch(t.root, keybytesToHex(key), 0, t.getRootEpoch())
+		value, newroot, didResolve, err = t.getWithEpoch(t.root, keybytesToHex(key), 0, t.getRootEpoch(), false)
 	} else {
 		value, newroot, didResolve, err = t.get(t.root, keybytesToHex(key), 0)
 	}
+	if err == nil && didResolve {
+		t.root = newroot
+	}
+	return value, err
+}
+
+func (t *Trie) GetAndUpdateEpoch(key []byte) (value []byte, err error) {
+	if !t.enableExpiry {
+		return nil, errors.New("expiry is not enabled")
+	}
+
+	value, newroot, didResolve, err := t.getWithEpoch(t.root, keybytesToHex(key), 0, t.getRootEpoch(), true)
+
 	if err == nil && didResolve {
 		t.root = newroot
 	}
@@ -232,7 +246,7 @@ func (t *Trie) get(origNode node, key []byte, pos int) (value []byte, newnode no
 	}
 }
 
-func (t *Trie) getWithEpoch(origNode node, key []byte, pos int, epoch types.StateEpoch) (value []byte, newnode node, didResolve bool, err error) {
+func (t *Trie) getWithEpoch(origNode node, key []byte, pos int, epoch types.StateEpoch, updateEpoch bool) (value []byte, newnode node, didResolve bool, err error) {
 	if t.epochExpired(origNode, epoch) {
 		return nil, nil, false, NewExpiredNodeError(key[:pos], epoch)
 	}
@@ -246,20 +260,28 @@ func (t *Trie) getWithEpoch(origNode node, key []byte, pos int, epoch types.Stat
 			// key not found in trie
 			return nil, n, false, nil
 		}
-		value, newnode, didResolve, err = t.getWithEpoch(n.Val, key, pos+len(n.Key), epoch)
-		if err == nil && t.renewNode(epoch, didResolve, true) {
+		value, newnode, didResolve, err = t.getWithEpoch(n.Val, key, pos+len(n.Key), epoch, updateEpoch)
+		if err == nil && t.renewNode(epoch, didResolve, updateEpoch) {
 			n = n.copy()
 			n.Val = newnode
-			n.setEpoch(t.getRootEpoch())
+			if updateEpoch {
+				n.setEpoch(t.currentEpoch)
+			}
+			didResolve = true
 		}
 		return value, n, didResolve, err
 	case *fullNode:
-		value, newnode, didResolve, err = t.getWithEpoch(n.Children[key[pos]], key, pos+1, n.GetChildEpoch(int(key[pos])))
-		if err == nil && t.renewNode(epoch, didResolve, true) {
+		value, newnode, didResolve, err = t.getWithEpoch(n.Children[key[pos]], key, pos+1, n.GetChildEpoch(int(key[pos])), updateEpoch)
+		if err == nil && t.renewNode(epoch, didResolve, updateEpoch) {
 			n = n.copy()
 			n.Children[key[pos]] = newnode
-			n.setEpoch(t.getRootEpoch())
-			n.UpdateChildEpoch(int(key[pos]), t.getRootEpoch())
+			if updateEpoch {
+				n.setEpoch(t.currentEpoch)
+			}
+			if updateEpoch && newnode != nil {
+				n.UpdateChildEpoch(int(key[pos]), t.currentEpoch)
+			}
+			didResolve = true
 		}
 		return value, n, didResolve, err
 	case hashNode:
@@ -275,7 +297,7 @@ func (t *Trie) getWithEpoch(origNode node, key []byte, pos int, epoch types.Stat
 			}
 			child.SetEpochMap(epochMap)
 		}
-		value, newnode, _, err := t.getWithEpoch(child, key, pos, epoch)
+		value, newnode, _, err := t.getWithEpoch(child, key, pos, epoch, updateEpoch)
 		return value, newnode, true, err
 	default:
 		panic(fmt.Sprintf("%T: invalid node: %v", origNode, origNode))
@@ -543,22 +565,23 @@ func (t *Trie) insertWithEpoch(n node, prefix, key []byte, value node, epoch typ
 			if !t.renewNode(epoch, dirty, true) || err != nil {
 				return false, n, err
 			}
-			return true, &shortNode{Key: n.Key, Val: nn, flags: t.newFlag(), epoch: epoch}, nil
+			return true, &shortNode{Key: n.Key, Val: nn, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 		}
 		// Otherwise branch out at the index where they differ.
-		branch := &fullNode{flags: t.newFlag(), epoch: epoch}
+		branch := &fullNode{flags: t.newFlag(), epoch: t.currentEpoch}
 		var err error
-		_, branch.Children[n.Key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, n.Key[:matchlen+1]...), n.Key[matchlen+1:], n.Val, epoch)
+		_, branch.Children[n.Key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, n.Key[:matchlen+1]...), n.Key[matchlen+1:], n.Val, t.currentEpoch)
 		if err != nil {
 			return false, nil, err
 		}
-		branch.UpdateChildEpoch(int(n.Key[matchlen]), epoch)
+		branch.UpdateChildEpoch(int(n.Key[matchlen]), t.currentEpoch)
 
-		_, branch.Children[key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, key[:matchlen+1]...), key[matchlen+1:], value, epoch)
+		_, branch.Children[key[matchlen]], err = t.insertWithEpoch(nil, append(prefix, key[:matchlen+1]...), key[matchlen+1:], value, t.currentEpoch)
 		if err != nil {
 			return false, nil, err
 		}
-		branch.UpdateChildEpoch(int(key[matchlen]), epoch)
+		branch.UpdateChildEpoch(int(key[matchlen]), t.currentEpoch)
+		branch.setEpoch(t.currentEpoch)
 
 		// Replace this shortNode with the branch if it occurs at index 0.
 		if matchlen == 0 {
@@ -570,16 +593,19 @@ func (t *Trie) insertWithEpoch(n node, prefix, key []byte, value node, epoch typ
 		t.tracer.onInsert(append(prefix, key[:matchlen]...))
 
 		// Replace it with a short node leading up to the branch.
-		return true, &shortNode{Key: key[:matchlen], Val: branch, flags: t.newFlag(), epoch: epoch}, nil
+		return true, &shortNode{Key: key[:matchlen], Val: branch, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 
 	case *fullNode:
 		dirty, nn, err := t.insertWithEpoch(n.Children[key[0]], append(prefix, key[0]), key[1:], value, n.GetChildEpoch(int(key[0])))
-		if !dirty || err != nil {
+		if !t.renewNode(epoch, dirty, true) || err != nil {
 			return false, n, err
 		}
 		n = n.copy()
 		n.flags = t.newFlag()
 		n.Children[key[0]] = nn
+		n.setEpoch(t.currentEpoch)
+		n.UpdateChildEpoch(int(key[0]), t.currentEpoch)
+
 		return true, n, nil
 
 	case nil:
@@ -588,7 +614,7 @@ func (t *Trie) insertWithEpoch(n node, prefix, key []byte, value node, epoch typ
 		// since it's always embedded in its parent.
 		t.tracer.onInsert(prefix)
 
-		return true, &shortNode{Key: key, Val: value, flags: t.newFlag(), epoch: epoch}, nil
+		return true, &shortNode{Key: key, Val: value, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 
 	case hashNode:
 		// We've hit a part of the trie that isn't loaded yet. Load
@@ -827,9 +853,9 @@ func (t *Trie) deleteWithEpoch(n node, prefix, key []byte, epoch types.StateEpoc
 			// always creates a new slice) instead of append to
 			// avoid modifying n.Key since it might be shared with
 			// other nodes.
-			return true, &shortNode{Key: concat(n.Key, child.Key...), Val: child.Val, flags: t.newFlag(), epoch: epoch}, nil
+			return true, &shortNode{Key: concat(n.Key, child.Key...), Val: child.Val, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 		default:
-			return true, &shortNode{Key: n.Key, Val: child, flags: t.newFlag(), epoch: epoch}, nil
+			return true, &shortNode{Key: n.Key, Val: child, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 		}
 
 	case *fullNode:
@@ -888,12 +914,12 @@ func (t *Trie) deleteWithEpoch(n node, prefix, key []byte, epoch types.StateEpoc
 					t.tracer.onDelete(append(prefix, byte(pos)))
 
 					k := append([]byte{byte(pos)}, cnode.Key...)
-					return true, &shortNode{Key: k, Val: cnode.Val, flags: t.newFlag()}, nil
+					return true, &shortNode{Key: k, Val: cnode.Val, flags: t.newFlag(), epoch: t.currentEpoch}, nil
 				}
 			}
 			// Otherwise, n is replaced by a one-nibble short node
 			// containing the child.
-			return true, &shortNode{Key: []byte{byte(pos)}, Val: n.Children[pos], flags: t.newFlag(), epoch: epoch}, nil
+			return true, &shortNode{Key: []byte{byte(pos)}, Val: n.Children[pos], flags: t.newFlag(), epoch: t.currentEpoch}, nil
 		}
 		// n still contains at least two values and cannot be reduced.
 		return true, n, nil
@@ -1050,7 +1076,7 @@ func (t *Trie) ReviveTrie(key []byte, prefixKeyHex []byte, proofList [][]byte) e
 	key = keybytesToHex(key)
 
 	// Verify the proof first
-	revivedNode, revivedHash, err := VerifyPathProof(key, prefixKeyHex, proofList, t.getRootEpoch())
+	revivedNode, revivedHash, err := VerifyPathProof(key, prefixKeyHex, proofList, t.currentEpoch)
 	if err != nil {
 		return err
 	}
@@ -1104,7 +1130,7 @@ func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedN
 		if err == nil && didRevived {
 			n = n.copy()
 			n.Val = newNode
-			n.setEpoch(t.getRootEpoch())
+			n.setEpoch(t.currentEpoch)
 		}
 		return n, didRevived, err
 	case *fullNode:
@@ -1114,8 +1140,8 @@ func (t *Trie) revive(n node, key []byte, prefixKeyHex []byte, pos int, revivedN
 		if err == nil && didRevived {
 			n = n.copy()
 			n.Children[key[pos]] = newNode
-			n.setEpoch(t.getRootEpoch())
-			n.UpdateChildEpoch(childIndex, t.getRootEpoch())
+			n.setEpoch(t.currentEpoch)
+			n.UpdateChildEpoch(childIndex, t.currentEpoch)
 		}
 		return n, didRevived, err
 	case hashNode:
@@ -1236,5 +1262,5 @@ func (t *Trie) epochExpired(n node, epoch types.StateEpoch) bool {
 	if !t.enableExpiry || n == nil {
 		return false
 	}
-	return types.EpochExpired(epoch, t.getRootEpoch())
+	return types.EpochExpired(epoch, t.currentEpoch)
 }


### PR DESCRIPTION
**Description**
- Add a feature to support storage trie revive from state object. Also added journal support.
- Modifies `MetaNoConsensus` type structure
- Accessing Trie updates node epoch with currentEpoch 

**Changes**
- `Trie` interface implements `ReviveTrie`
- Add journal items `reviveStorageTrieNodeChange` and `accessedStorageStateChange`
- `stateObject` implements `ReviveStorageTrie`
- Nodes set epoch with `t.currentEpoch` instead of `t.rootEpoch`
- Add `GetStorageAndUpdateEpoch` to `Trie` interface
- Add new `GetAndUpdateEpoch` to Trie struct. Normal `Get` function will not update nodes epoch.